### PR TITLE
Add portfolio template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Adam-PortfolioWebsite
+# Adam Portfolio Website
+
+This is a simple full stack template for a personal portfolio. It includes a Node.js backend using Express and a static frontend with modern styles and animations.
+
+## Setup
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+
+2. Start the server:
+   ```bash
+   npm start
+   ```
+
+The site will be available at `http://localhost:3000`.

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Portfolio Website",
+    "description": "A sleek portfolio with modern design and animations."
+  },
+  {
+    "title": "Blog Platform",
+    "description": "A simple blog application with markdown support."
+  },
+  {
+    "title": "E-commerce Demo",
+    "description": "Demo store showcasing shopping cart functionality."
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "adam-portfolio-website",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Adam's Portfolio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1 class="title">Welcome to My Portfolio</h1>
+    <p class="subtitle">Showcasing my work and skills</p>
+  </header>
+  <main>
+    <section id="projects" class="projects">
+      <h2>Projects</h2>
+      <div id="project-list" class="project-list"></div>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/api/projects')
+    .then(res => res.json())
+    .then(projects => {
+      const container = document.getElementById('project-list');
+      projects.forEach(p => {
+        const div = document.createElement('div');
+        div.className = 'project';
+        div.innerHTML = `<h3>${p.title}</h3><p>${p.description}</p>`;
+        container.appendChild(div);
+      });
+    })
+    .catch(err => console.error(err));
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,61 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #fff;
+  background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  min-height: 100vh;
+}
+
+.hero {
+  text-align: center;
+  padding: 80px 20px;
+  background: radial-gradient(circle at top left, rgba(255,255,255,0.1), transparent),
+              radial-gradient(circle at bottom right, rgba(255,255,255,0.1), transparent);
+  animation: fadeIn 2s ease-in-out;
+}
+
+.title {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  animation: slideIn 1s forwards;
+}
+
+.subtitle {
+  font-size: 1.2rem;
+  opacity: 0.8;
+}
+
+.projects {
+  padding: 40px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.project-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.project {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 8px;
+  backdrop-filter: blur(5px);
+  transition: transform 0.3s;
+}
+
+.project:hover {
+  transform: translateY(-5px);
+}
+
+@keyframes slideIn {
+  from { transform: translateY(-30px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/projects', (req, res) => {
+  const projects = require('./data/projects.json');
+  res.json(projects);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- build an Express server with a basic API
- add portfolio HTML/CSS/JS with animations
- include sample project data and installation instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b231e235c832c9aa8ac58569dec3e