### PR TITLE
Improve hero layout and canvas animation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
 <body>
   <canvas id="bg-canvas" aria-hidden="true"></canvas>
   <header class="hero">
+    <h1 class="title">Welcome to My Portfolio</h1>
+    <p class="subtitle">Showcasing my work and skills</p>
     <div class="profile-pic">
       <img src="profile.jpg" alt="Profile picture" />
     </div>
-    <h1 class="title">Welcome to My Portfolio</h1>
-    <p class="subtitle">Showcasing my work and skills</p>
   </header>
   <main>
     <section id="projects" class="projects">

--- a/public/script.js
+++ b/public/script.js
@@ -27,26 +27,36 @@ function startCanvas() {
   window.addEventListener('resize', resize);
   resize();
 
-  const spacing = 60;
-  const lineCount = 5;
+  const spacing = 40;
+  const lineCount = 6;
   const lines = Array.from({ length: lineCount }, () => ({
-    speed: 0.5 + Math.random(),
+    speed: 0.3 + Math.random(),
     offset: 0,
     points: []
   }));
 
   function initLines() {
-    const needed = Math.ceil(canvas.width / spacing) + 2;
+    const needed = Math.ceil(canvas.width / spacing) + 3;
     lines.forEach(line => {
       line.points = [];
+      let y = randY();
       for (let i = 0; i < needed; i++) {
-        line.points.push({ x: i * spacing, y: randY() });
+        line.points.push({ x: i * spacing, y });
+        y = nextY(y);
       }
     });
   }
 
   function randY() {
     return Math.random() * canvas.height * 0.6 + canvas.height * 0.2;
+  }
+
+  function nextY(prevY) {
+    const range = canvas.height * 0.15;
+    let y = prevY + (Math.random() - 0.5) * range;
+    const min = canvas.height * 0.2;
+    const max = canvas.height * 0.8;
+    return Math.max(min, Math.min(max, y));
   }
 
   function draw() {
@@ -56,19 +66,26 @@ function startCanvas() {
 
     lines.forEach(line => {
       ctx.beginPath();
-      line.points.forEach((pt, i) => {
+      for (let i = 0; i < line.points.length - 1; i++) {
+        const pt = line.points[i];
+        const next = line.points[i + 1];
         const x = pt.x - line.offset;
-        if (i === 0) ctx.moveTo(x, pt.y);
-        else ctx.lineTo(x, pt.y);
-      });
+        const nx = next.x - line.offset;
+        const xc = (x + nx) / 2;
+        const yc = (pt.y + next.y) / 2;
+        if (i === 0) {
+          ctx.moveTo(x, pt.y);
+        }
+        ctx.quadraticCurveTo(x, pt.y, xc, yc);
+      }
       ctx.stroke();
 
       line.offset += line.speed;
       if (line.offset >= spacing) {
         line.offset -= spacing;
         line.points.shift();
-        const lastX = line.points[line.points.length - 1].x;
-        line.points.push({ x: lastX + spacing, y: randY() });
+        const last = line.points[line.points.length - 1];
+        line.points.push({ x: last.x + spacing, y: nextY(last.y) });
       }
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -34,7 +34,7 @@ body {
 .profile-pic {
   width: 150px;
   height: 150px;
-  margin: 0 auto 20px;
+  margin: 20px auto 0;
 }
 
 .profile-pic img {


### PR DESCRIPTION
## Summary
- move the profile image below the hero title and subtitle
- add margin adjustments for the new layout
- increase line detail in canvas animation and smooth transitions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c1cd644832cae26d6485f276f3a