### PR TITLE
Improve project card width on large screens

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -60,7 +60,7 @@ body {
 
 .projects {
   padding: 40px 20px;
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -69,6 +69,12 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 20px;
   margin-top: 20px;
+}
+
+@media (min-width: 1000px) {
+  .project-list {
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  }
 }
 
 .project {


### PR DESCRIPTION
## Summary
- widen the Projects section container
- increase minimum project card width on screens wider than 1000px

## Testing
- `npm start` *(server starts successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684b5baf7c88832ca604d8b94c83f75c