### PR TITLE
Fix chart labels staying with points

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -145,6 +145,8 @@ function startCanvas() {
     // move points left and add new ones when needed
     points.forEach(pt => {
       pt.x -= speed;
+      pt.labelX = pt.x; // keep value labels aligned with points
+      pt.labelY = pt.y;
       pt.value = yToValue(pt.y).toFixed(2);
     });
     if (points[0].x <= -spacing) {


### PR DESCRIPTION
## Summary
- keep numerical labels aligned with their graph points during animation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b974e43ec832cbad4637f5a432969