### PR TITLE
Fix value label jitter

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -76,7 +76,8 @@ function startCanvas() {
         y,
         value: value.toFixed(2),
         labelX: x,
-        labelY: y
+        labelY: y,
+        showLabel: i % 2 === 0
       });
       lastValue = value;
       y = nextY(y);
@@ -133,11 +134,11 @@ function startCanvas() {
     ctx.font = '12px monospace';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'bottom';
-    points.forEach((pt, idx) => {
+    points.forEach(pt => {
       ctx.beginPath();
       ctx.arc(pt.x, pt.y, 3, 0, Math.PI * 2);
       ctx.fill();
-      if (idx % 2 === 0) {
+      if (pt.showLabel) {
         ctx.fillText(pt.value, pt.labelX, pt.labelY - 8);
       }
     });
@@ -160,7 +161,8 @@ function startCanvas() {
         y: newY,
         value: newValue.toFixed(2),
         labelX: newX,
-        labelY: newY
+        labelY: newY,
+        showLabel: !lastPt.showLabel
       });
 
       // update stock block on new point


### PR DESCRIPTION
## Summary
- keep value labels associated with each point
- maintain alternating label pattern as new points are added

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b9c6a6c10832c825c353e80ea92cc