### PR TITLE
Align bar graph with hero header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,8 @@
   <canvas id="bg-canvas" aria-hidden="true"></canvas>
   <div id="stock-block" class="stock-block"></div>
   <header class="hero">
-    <h1 class="title">Hi, I'm <strong>Adam Walid</strong></h1>
     <div id="bar-container" class="bar-container" aria-hidden="true"></div>
+    <h1 class="title">Hi, I'm <strong>Adam Walid</strong></h1>
     <p class="subtitle">Data Science & Full-Stack Developer | CS + Data Analytics @ Syracuse University</p>
     <div class="profile-pic">
       <img src="images/linkedin.jpg" alt="Profile picture" />

--- a/public/script.js
+++ b/public/script.js
@@ -185,8 +185,11 @@ function startCanvas() {
 
 function initBars() {
   const container = document.getElementById('bar-container');
-  if (!container) return;
+  const header = document.querySelector('h1.title');
+  if (!container || !header) return;
+
   const numBars = 20;
+  const gap = 3; // keep in sync with CSS
   const bars = [];
   for (let i = 0; i < numBars; i++) {
     const bar = document.createElement('div');
@@ -195,9 +198,25 @@ function initBars() {
     bars.push(bar);
   }
 
-  function animate() {
+  function setSize() {
+    const width = header.offsetWidth;
+    const height = header.offsetHeight * 0.8;
+    container.style.width = `${width}px`;
+    container.style.height = `${height}px`;
+    const barWidth = (width - gap * (numBars - 1)) / numBars;
     bars.forEach(bar => {
-      const height = Math.random() * 30 + 10; // 10-40px
+      bar.style.width = `${barWidth}px`;
+    });
+  }
+
+  window.addEventListener('resize', setSize);
+  // wait a tick for fonts to load
+  setTimeout(setSize, 0);
+
+  function animate() {
+    const maxHeight = container.clientHeight;
+    bars.forEach(bar => {
+      const height = Math.random() * maxHeight;
       bar.style.height = `${height}px`;
     });
     const delay = Math.random() * 300 + 200;

--- a/public/style.css
+++ b/public/style.css
@@ -165,8 +165,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  height: 40px;
-  margin-top: 10px;
+  margin: 0 auto 10px;
   gap: 3px;
 }
 


### PR DESCRIPTION
## Summary
- move bar graph container above the hero header
- adjust bar graph styling
- size bar graph to the header width and height via script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbc5f8cd8832caf1145c3a02cc5e5