### PR TITLE
Improve bar width sizing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -52,6 +52,7 @@ body {
   margin-bottom: 0.5rem;
   color: var(--accent-gray);
   animation: slideIn 1s forwards;
+  display: inline-block;
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- limit bar graph width by letting the h1 element size to its text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbdab3b7c832c800d79e79c94d2ad