### PR TITLE
Add contact info to page header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,11 @@
     <div class="profile-pic">
       <img src="images/linkedin.jpg" alt="Profile picture" />
     </div>
+    <div class="header-contact">
+      <a href="mailto:adamwalidprof@gmail.com">Email</a>
+      <a href="https://www.linkedin.com/in/adamwalid/" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://github.com/adamwalid64" target="_blank" rel="noopener">GitHub</a>
+    </div>
   </header>
   <main>
     <section id="projects" class="projects">

--- a/public/style.css
+++ b/public/style.css
@@ -47,6 +47,22 @@ body {
   border: 3px solid var(--accent-gray);
 }
 
+.header-contact {
+  margin-top: 15px;
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+}
+
+.header-contact a {
+  color: var(--accent-gray);
+  text-decoration: none;
+}
+
+.header-contact a:hover {
+  text-decoration: underline;
+}
+
 .title {
   font-size: 3rem;
   margin-top: 0; /* tighten spacing with bar graph */


### PR DESCRIPTION
## Summary
- show key contact links in the header for quick access
- style header contact links

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js &`

------
https://chatgpt.com/codex/tasks/task_e_684bc0e967d4832ca76446ba0ae398cf