### PR TITLE
Improve server startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const path = require('path');
 const app = express();
-const PORT = process.env.PORT || 3000;
+
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -10,6 +11,19 @@ app.get('/api/projects', (req, res) => {
   res.json(projects);
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+function startServer(port) {
+  const server = app.listen(port);
+  server.on('listening', () => {
+    console.log(`Server running on port ${port}`);
+  });
+  server.on('error', err => {
+    if (err.code === 'EADDRINUSE') {
+      console.log(`Port ${port} in use, trying ${port + 1}`);
+      startServer(port + 1);
+    } else {
+      throw err;
+    }
+  });
+}
+
+startServer(DEFAULT_PORT);


### PR DESCRIPTION
## Summary
- auto-handle port conflicts by retrying on the next port when the default port is in use

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686f686fc2e0832cb8bf7994868ffee4